### PR TITLE
fix: carrega os dicionários pelo bundle para matar cache velho de locale

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -27,7 +27,7 @@
                 "glob": "**/*",
                 "input": "src/assets",
                 "output": "assets",
-                "ignore": ["images/masters/**", "images/masters-hero/**"]
+                "ignore": ["images/masters/**", "images/masters-hero/**", "i18n/**"]
               }
             ],
             "styles": ["src/styles.css", "src/styles/fonts/fonts.css", "src/styles/icons.css"],

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -7,15 +7,15 @@ import {
   provideAppInitializer
 } from '@angular/core';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
-import { TRANSLATE_HTTP_LOADER_CONFIG, TranslateHttpLoader } from '@ngx-translate/http-loader';
 
 import { GlobalErrorHandler } from './core/error-handling/global-error-handler';
+import { BundledTranslateLoader } from './core/i18n/bundled-translate.loader';
 import { LocaleService } from './core/i18n/locale.service';
 import { DEFAULT_LOCALE } from './core/i18n/locales';
 import { MonitoringService } from './core/monitoring/monitoring.service';
 
 export function HttpLoaderFactory() {
-  return new TranslateHttpLoader();
+  return new BundledTranslateLoader();
 }
 
 export const appConfig: ApplicationConfig = {
@@ -24,10 +24,6 @@ export const appConfig: ApplicationConfig = {
     { provide: ErrorHandler, useClass: GlobalErrorHandler },
     provideAppInitializer(() => inject(MonitoringService).start()),
     provideAppInitializer(() => inject(LocaleService).init()),
-    {
-      provide: TRANSLATE_HTTP_LOADER_CONFIG,
-      useValue: { prefix: 'assets/i18n/', suffix: '.json' }
-    },
     importProvidersFrom(
       TranslateModule.forRoot({
         loader: {

--- a/src/app/core/i18n/bundled-translate.loader.spec.ts
+++ b/src/app/core/i18n/bundled-translate.loader.spec.ts
@@ -1,0 +1,43 @@
+import { firstValueFrom } from 'rxjs';
+
+import { BundledTranslateLoader } from './bundled-translate.loader';
+
+describe('BundledTranslateLoader', () => {
+  const loader = new BundledTranslateLoader();
+
+  // As chaves que o visitante viu cruas na tela quando o `pt.json` velho ficou
+  // preso em cache. Se alguma sair do dicionário, o gate acusa antes do deploy.
+  const REGRESSION_KEYS = [
+    ['CTA', 'viewFeatured'],
+    ['CTA', 'downloadCv'],
+    ['projects', 'redirect'],
+    ['projects', 'all', 'show'],
+    ['skills', 'practice', 'title'],
+    ['roadmap', 'history', 'show']
+  ];
+
+  const read = (dictionary: unknown, path: string[]): unknown =>
+    path.reduce<unknown>(
+      (node, key) => (node as Record<string, unknown> | undefined)?.[key],
+      dictionary
+    );
+
+  it('resolves every locale without a network request for assets/i18n', async () => {
+    for (const locale of ['pt', 'en']) {
+      const dictionary = await firstValueFrom(loader.getTranslation(locale));
+
+      expect(Object.keys(dictionary).length).toBeGreaterThan(0);
+      for (const path of REGRESSION_KEYS) {
+        expect(read(dictionary, path))
+          .withContext(`${locale}: ${path.join('.')}`)
+          .toEqual(jasmine.any(String));
+      }
+    }
+  });
+
+  it('falls back to the default locale instead of resolving an empty dictionary', async () => {
+    const dictionary = await firstValueFrom(loader.getTranslation('tlh'));
+
+    expect(read(dictionary, ['CTA', 'viewFeatured'])).toBe('Ver cases em destaque');
+  });
+});

--- a/src/app/core/i18n/bundled-translate.loader.ts
+++ b/src/app/core/i18n/bundled-translate.loader.ts
@@ -1,0 +1,33 @@
+import { TranslateLoader, TranslationObject } from '@ngx-translate/core';
+import { from, Observable } from 'rxjs';
+
+import { DEFAULT_LOCALE, isLocale, Locale } from './locales';
+
+/**
+ * Carrega os dicionários por `import()` em vez de buscar `assets/i18n/*.json`
+ * por HTTP.
+ *
+ * O motivo é um bug que chegou ao visitante: enquanto `/assets/*` respondia com
+ * cache imutável, os navegadores guardaram uma cópia antiga de `pt.json` e
+ * pararam de revalidar. Quem tinha essa cópia passou a ver a chave crua na tela
+ * — `CTA.viewFeatured`, `projects.redirect`, `skills.practice.*` — porque o
+ * dicionário em cache não conhecia as chaves novas. O header já foi corrigido,
+ * mas cache velho não se conserta pelo servidor: só deixa de ser usado quando o
+ * arquivo deixa de ser buscado por uma URL estável.
+ *
+ * Como chunk gerado pelo build, o dicionário passa a ter hash de conteúdo no
+ * nome. Cópia velha nunca é reutilizada, e só o idioma em uso é baixado.
+ */
+const DICTIONARIES: Record<Locale, () => Promise<TranslationObject>> = {
+  pt: () =>
+    import('../../../assets/i18n/pt.json').then((module) => module.default as TranslationObject),
+  en: () =>
+    import('../../../assets/i18n/en.json').then((module) => module.default as TranslationObject)
+};
+
+export class BundledTranslateLoader implements TranslateLoader {
+  getTranslation(lang: string): Observable<TranslationObject> {
+    const locale = isLocale(lang) ? lang : DEFAULT_LOCALE;
+    return from(DICTIONARIES[locale]());
+  }
+}


### PR DESCRIPTION
## O sintoma

Em produção, o visitante em pt-BR via chave crua na tela: `CTA.viewFeatured`, `CTA.downloadCv`, `projects.redirect`, `projects.all.show`, `skills.practice.*` e `roadmap.history.show`. Em inglês funcionava.

## A causa não é conteúdo

Descartado por medição, não por leitura:

- os dois locales têm **338 chaves cada**, com conjuntos idênticos — zero chave só em um lado;
- o `pt.json` **servido em produção** responde com todos os valores certos (`"Ver cases em destaque"`, `"Baixar CV"`, `"Redirecionar"`…).

O que falhou foi cache do navegador. Enquanto `/assets/*` respondia com cache imutável — o mesmo defeito que o P0 item 22 da auditoria descreveu — o navegador guardou uma cópia de `pt.json` e parou de revalidar. Essa cópia é anterior ao commit `114fef0`, que criou justamente essas chaves. O header já foi corrigido para `max-age=0, must-revalidate`, mas **header novo não limpa cache velho**: a cópia presa só deixa de ser usada quando o arquivo deixa de ser buscado por uma URL estável.

Foi por isso que só o pt quebrou: o en nunca teve cópia velha equivalente.

## A correção

Os dicionários passam a entrar por `import()` dinâmico em vez de `TranslateHttpLoader`. O build os emite como chunk com **hash de conteúdo** no nome, então:

- cópia velha nunca é reutilizada — o nome muda quando o conteúdo muda;
- só o idioma em uso é baixado;
- `assets/i18n` sai do build, porque não há mais quem busque essa URL.

## Custo

| | antes | depois |
| --- | --- | --- |
| Bundle inicial | 517,41 kB / 133,60 kB | 517,15 kB / 134,16 kB |
| Dicionário pt | requisição HTTP de 9,7 kB gz | chunk de 8,83 kB |
| Dicionário en | requisição HTTP de 9,3 kB gz | chunk de 7,71 kB |

Sai uma requisição HTTP que bloqueava texto visível no caminho crítico.

## Gate

`lint`, `format:check`, `i18n:check` (338 × 2), **51 testes** e build, todos verdes. Dois testes novos em `bundled-translate.loader.spec.ts`: o primeiro exige que as seis chaves que apareceram cruas existam nos dois locales, o segundo cobre o fallback de locale desconhecido. Verificado também em execução — a página renderiza pt correto com **zero requisições a `/assets/i18n`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)