### PR TITLE
fix(hero): troca o 12x pelo numero de projetos no ar

### DIFF
--- a/src/app/components/hero/hero.component.spec.ts
+++ b/src/app/components/hero/hero.component.spec.ts
@@ -56,8 +56,22 @@ describe('HeroComponent', () => {
     // O valor final já está no HTML: se o observador não rodar, o visitante lê
     // o número certo em vez de "0+".
     expect(stats).toEqual(['5+', '35+']);
-    expect(host.textContent).toContain('stats.measuredSpeedup');
+    expect(host.textContent).toContain('stats.liveProjects');
     expect(host.textContent).not.toContain('stats.languagesDominated');
+    expect(host.textContent).not.toContain('stats.measuredSpeedup');
+  });
+
+  it('states the live-project count exactly, without the counter suffix', () => {
+    const host: HTMLElement = fixture.nativeElement;
+    const label = Array.from(host.querySelectorAll('div')).find((element) =>
+      element.textContent?.trim().startsWith('stats.liveProjects')
+    );
+    const value = label?.previousElementSibling as HTMLElement | null;
+
+    // Contado, não estimado: o contador anima com sufixo "+", e "14+" mentiria
+    // sobre um número que o visitante confere clicando nos cards.
+    expect(value?.textContent?.trim()).toBe('14');
+    expect(value?.classList.contains('stat-number')).toBeFalse();
   });
 
   it('offers the CV in both languages as downloadable one-page PDFs', () => {

--- a/src/app/components/hero/hero.component.ts
+++ b/src/app/components/hero/hero.component.ts
@@ -180,9 +180,10 @@ import { NavService } from '../../core/services/nav.service';
           </div>
 
           <!-- Stats. Nenhum é auto-elogio: os três apontam para algo medido ou
-               contado. O "12x" é o case de decisão do portal de fechamento, que
-               saiu de 4.271 ms para 354 ms e está publicado no modal com
-               contexto, evidência e impacto. -->
+               contado. O terceiro é o único que o visitante confere sozinho —
+               são os cards com demo pública que respondem 2xx, medidos em
+               2026-08-12. Número exato, sem "+": se um domínio cair, o número
+               cai junto, e é assim que ele continua verdadeiro. -->
           <div class="mx-auto grid max-w-3xl grid-cols-1 gap-8 md:grid-cols-3">
             <div class="group text-center">
               <div
@@ -210,10 +211,10 @@ import { NavService } from '../../core/services/nav.service';
               <div
                 class="mb-2 font-heading text-4xl font-bold text-accent-600 transition-transform group-hover:scale-110 dark:text-accent-400"
               >
-                12x
+                14
               </div>
               <div class="font-sans font-medium text-neutral-600 dark:text-neutral-400">
-                {{ 'stats.measuredSpeedup' | translate }}
+                {{ 'stats.liveProjects' | translate }}
               </div>
             </div>
           </div>

--- a/src/app/components/projects/projects.json
+++ b/src/app/components/projects/projects.json
@@ -100,7 +100,6 @@
       "category": "commercial",
       "tagsKeys": ["projects.tags.ecommerce", "projects.tags.food", "projects.tags.landing_page"],
       "technologies": ["HTML5", "CSS3", "JavaScript", "jQuery", "Bootstrap"],
-      "demoUrl": "https://minhamaquinadeleads.com.br/20c67a70",
       "decision": {
         "provesKey": "projects.decisions.fehe_chocolate.proves",
         "contextKey": "projects.decisions.fehe_chocolate.context",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -27,7 +27,7 @@
     "yearsOfExperience": "Years of Experience",
     "completedProjects": "Completed Projects",
     "languagesDominated": "Languages Dominated",
-    "measuredSpeedup": "Faster in the measured case"
+    "liveProjects": "Live projects"
   },
   "about": {
     "aboutMe": "About Me",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -27,7 +27,7 @@
     "yearsOfExperience": "Anos de Experiência",
     "completedProjects": "Projetos Concluídos",
     "languagesDominated": "Idiomas Dominados",
-    "measuredSpeedup": "Mais rápido no case medido"
+    "liveProjects": "Projetos no ar"
   },
   "about": {
     "aboutMe": "Sobre Mim",


### PR DESCRIPTION
## O que muda

O terceiro indicador do herói sai de **12x mais rápido no case medido** para **14 projetos no ar**.

O número antigo era honesto (o portal de fechamento saiu de 4.271 ms para 354 ms, com evidência publicada no modal), mas exigia abrir um modal e ler um case de decisão para fazer sentido. Ao lado de "5+ anos" e "35+ projetos", ele quebrava a primeira leitura em vez de sustentá-la.

## Por que 14

São os cards com demo pública que respondem 2xx, medidos em 2026-08-12. É o único dos três indicadores que o visitante confere sozinho — basta clicar.

Renderizado **sem `+` e sem a classe `.stat-number`**, de propósito: o contador de entrada anima escrevendo `${current}+`, e "14+" mentiria sobre um número exato que qualquer um pode recontar na própria página.

## Link morto encontrado no caminho

A demo do `fehe-chocolate` (`minhamaquinadeleads.com.br`) resolve no DNS mas o servidor não responde — timeout de 15 s. Era link morto oferecido como ação primária do card. Removido: sem isso, a página ofereceria 15 demos enquanto o herói contaria 14.

## Gate

`format:check`, `lint`, `i18n:check` (533 chaves por locale), **88 testes** (eram 87), `build` e `security:audit`.

Verificado no DOM com o dev server no ar: valor `14`, rótulo `Projetos no ar`, sem a classe do contador. A captura de tela não pôde ser feita — o painel do navegador desta sessão não alcança o dev server aberto por outra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)