### PR TITLE
fix(projects): devolve a demo do fehe-chocolate e corrige o indicador

### DIFF
--- a/src/app/components/hero/hero.component.spec.ts
+++ b/src/app/components/hero/hero.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 
+import projectsData from '../projects/projects.json';
 import { HeroComponent } from './hero.component';
 
 describe('HeroComponent', () => {
@@ -68,10 +69,17 @@ describe('HeroComponent', () => {
     );
     const value = label?.previousElementSibling as HTMLElement | null;
 
-    // Contado, não estimado: o contador anima com sufixo "+", e "14+" mentiria
+    // Contado, não estimado: o contador anima com sufixo "+", e "15+" mentiria
     // sobre um número que o visitante confere clicando nos cards.
-    expect(value?.textContent?.trim()).toBe('14');
+    expect(value?.textContent?.trim()).toBe('15');
     expect(value?.classList.contains('stat-number')).toBeFalse();
+
+    // Prende o número ao catálogo. Sem isto, alguém tira uma demo do JSON e o
+    // herói continua anunciando o total antigo, sem nada quebrar.
+    const withDemo = [...projectsData.commercial, ...projectsData.study].filter(
+      (project) => 'demoUrl' in project
+    );
+    expect(value?.textContent?.trim()).toBe(String(withDemo.length));
   });
 
   it('offers the CV in both languages as downloadable one-page PDFs', () => {

--- a/src/app/components/hero/hero.component.ts
+++ b/src/app/components/hero/hero.component.ts
@@ -181,9 +181,9 @@ import { NavService } from '../../core/services/nav.service';
 
           <!-- Stats. Nenhum é auto-elogio: os três apontam para algo medido ou
                contado. O terceiro é o único que o visitante confere sozinho —
-               são os cards com demo pública que respondem 2xx, medidos em
-               2026-08-12. Número exato, sem "+": se um domínio cair, o número
-               cai junto, e é assim que ele continua verdadeiro. -->
+               são os cards com demo pública no ar, conferidos em 2026-08-12.
+               Número exato, sem "+": se um domínio cair, o número cai junto, e
+               é assim que ele continua verdadeiro. -->
           <div class="mx-auto grid max-w-3xl grid-cols-1 gap-8 md:grid-cols-3">
             <div class="group text-center">
               <div
@@ -211,7 +211,7 @@ import { NavService } from '../../core/services/nav.service';
               <div
                 class="mb-2 font-heading text-4xl font-bold text-accent-600 transition-transform group-hover:scale-110 dark:text-accent-400"
               >
-                14
+                15
               </div>
               <div class="font-sans font-medium text-neutral-600 dark:text-neutral-400">
                 {{ 'stats.liveProjects' | translate }}

--- a/src/app/components/projects/projects.json
+++ b/src/app/components/projects/projects.json
@@ -100,6 +100,7 @@
       "category": "commercial",
       "tagsKeys": ["projects.tags.ecommerce", "projects.tags.food", "projects.tags.landing_page"],
       "technologies": ["HTML5", "CSS3", "JavaScript", "jQuery", "Bootstrap"],
+      "demoUrl": "https://minhamaquinadeleads.com.br/20c67a70",
       "decision": {
         "provesKey": "projects.decisions.fehe_chocolate.proves",
         "contextKey": "projects.decisions.fehe_chocolate.context",


### PR DESCRIPTION
## O que aconteceu

O link da demo do `fehe-chocolate` foi removido em `074fa59` porque a medição daqui não conseguia completar conexão com `minhamaquinadeleads.com.br` — DNS resolvia, HTTP estourava 15 s sem um byte. Li isso como servidor morto.

**Estava errado.** O Augusto abriu a URL e o site FEHE responde normalmente, na mesma URL com path. A falha era do caminho de rede da medição, não do destino.

## O que muda

- `demoUrl` do `fehe-chocolate` volta ao catálogo, na posição original.
- O indicador do herói vai de **14** para **15** — 15 de 15 demos no ar.
- O teste passou a **derivar o número do próprio catálogo**, além de fixá-lo. Sem isso, remover uma demo do JSON deixa o herói anunciando o total antigo e nada quebra: foi exatamente o modo de falha desta rodada, invertido.

## Gate

`format:check`, `lint`, `i18n:check`, **88 testes**, `build` e `security:audit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)