### PR TITLE
fix: set Angular framework for Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "angular",
   "outputDirectory": "dist/portfolio-augusto/browser",
   "rewrites": [{ "source": "/((?!assets/).*)", "destination": "/index.html" }],
   "headers": [


### PR DESCRIPTION
## Summary
- override the Vercel project preset with the Angular framework slug
- preserve the existing Angular output directory, SPA rewrite and security headers

## Validation
- npm run build
- JSON parsing
- git diff --check

The preceding deployment served a Next.js build despite this repository being Angular; Vercel documents that  in  overrides the dashboard preset.